### PR TITLE
Fix UUID fields are being parsed to an int

### DIFF
--- a/src/buildQuery.ts
+++ b/src/buildQuery.ts
@@ -38,7 +38,7 @@ let typeMap: any
 let queryMap: QueryMap
 
 const mapType = (idType: any, value: string | number) =>
-  idType.name === 'String' ? value : parseInt(value as string, 10)
+  idType.name === 'String' ? value : idType.name === 'UUID' ? value : parseInt(value as string, 10)
 
 export const buildQuery = (introspectionResults: any, factory: Factory) => (
   raFetchType: string,


### PR DESCRIPTION
This fixes when a GET_ONE MyResource {id: "12abcdef-1234-1234-1234-1234567890ab"} is being parsed and a graphql request being sent with { "id": 12 }.