### PR TITLE
Allow passing options to buildGraphQLProvider

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,11 +1,12 @@
 import buildGraphQLProvider from 'ra-data-graphql'
 import { buildQuery } from './buildQuery'
 import { defaultQueryValueToInputValueMap } from './defaultValueInputTypeMapping'
-import { ProviderOptions } from './types'
+import { ProviderOptions, GraphqlProviderOptions } from './types'
 
 export const factory = (
   client: any,
-  options: ProviderOptions = { queryValueToInputValueMap: {} }
+  options: ProviderOptions = { queryValueToInputValueMap: {} },
+  graphqlProviderOptions: GraphqlProviderOptions = {}
 ) => {
   const defaultAppliedOptions = {
     queryValueToInputValueMap: {
@@ -15,6 +16,7 @@ export const factory = (
   }
 
   return buildGraphQLProvider({
+    ...graphqlProviderOptions,
     client,
     buildQuery,
     options: defaultAppliedOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { GraphQLObjectType } from 'graphql'
+
 export interface QueryInputTypeMapper {
   [id: string]: (value: any) => any
 }
@@ -9,8 +11,21 @@ export interface ProviderOptions {
   queryValueToInputValueMap: QueryInputTypeMapper
 }
 
+export interface GraphqlProviderOptions {
+  introspection?: {
+    queryType: {
+      name: string
+    }
+    mutationType: {
+      name: string
+    }
+    types: GraphQLObjectType[]
+  }
+}
+
 export interface Factory {
   options: ProviderOptions
+  graphqlOptions: GraphqlProviderOptions
 }
 
 export type SortDirection = 'ASC' | 'DESC'


### PR DESCRIPTION
The only option that is currently allowed is "introspection".

Fixes #15