### PR TITLE
Add support for postgraphile's default condition block filtering

### DIFF
--- a/src/buildQuery.ts
+++ b/src/buildQuery.ts
@@ -175,11 +175,13 @@ export const buildQuery = (introspectionResults: IntrospectionResult, factory: F
       )
     case GET_LIST: {
       const { filter, sort, pagination } = params as GetManyReferenceParams
+      const { condition, ...pluginFilters } = filter || {}
+
       const orderBy =
         sort && sort.field && sort.order
           ? [createSortingKey(sort.field, sort.order as SortDirection)]
           : [NATURAL_SORTING]
-      const filters = createFilter(filter, type)
+      const filters = createFilter(pluginFilters, type)
       return {
         query: createGetListQuery(
           type,
@@ -197,6 +199,7 @@ export const buildQuery = (introspectionResults: IntrospectionResult, factory: F
           first: pagination.perPage,
           filter: filters,
           orderBy,
+          condition,
         }),
         parseResponse: (response: Response) => {
           const { nodes, totalCount } = response.data[manyLowerResourceName]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -297,19 +297,23 @@ export const createGetListQuery = (
   )
 
   if (!hasFilters && !hasOrdering) {
-    return gql`query ${manyLowerResourceName}($offset: Int!, $first: Int!) {
-      ${manyLowerResourceName}(first: $first, offset: $offset) {
-      nodes {
-        ${createQueryFromType(
-          resourceTypename,
-          typeMap,
-          typeConfiguration,
-          primaryKey,
-          fetchQueryType
-        )}
+    return gql`query ${manyLowerResourceName}(
+        $offset: Int!,
+        $first: Int!,
+        $condition = ${resourceTypename}Condition = {}
+      ) {
+        ${manyLowerResourceName}(first: $first, offset: $offset, condition: $condition) {
+        nodes {
+          ${createQueryFromType(
+            resourceTypename,
+            typeMap,
+            typeConfiguration,
+            primaryKey,
+            fetchQueryType
+          )}
+        }
+        totalCount
       }
-      totalCount
-    }
     }`
   }
 
@@ -318,8 +322,14 @@ export const createGetListQuery = (
     $offset: Int!,
     $first: Int!,
     $orderBy: [${pluralizedResourceTypeName}OrderBy!]
+    $condition: ${resourceTypename}Condition = {}
     ) {
-      ${manyLowerResourceName}(first: $first, offset: $offset, orderBy: $orderBy) {
+      ${manyLowerResourceName}(
+        first: $first,
+        offset: $offset,
+        orderBy: $orderBy,
+        condition: $condition
+      ) {
       nodes {
         ${createQueryFromType(
           resourceTypename,
@@ -339,8 +349,14 @@ export const createGetListQuery = (
     $offset: Int!,
     $first: Int!,
     $filter: ${resourceTypename}Filter,
+    $condition: ${resourceTypename}Condition = {}
     ) {
-      ${manyLowerResourceName}(first: $first, offset: $offset, filter: $filter) {
+      ${manyLowerResourceName}(
+        first: $first,
+        offset: $offset,
+        filter: $filter,
+        condition: $condition
+      ) {
       nodes {
         ${createQueryFromType(
           resourceTypename,
@@ -359,9 +375,16 @@ export const createGetListQuery = (
   $offset: Int!,
   $first: Int!,
   $filter: ${resourceTypename}Filter,
+  $condition: ${resourceTypename}Condition,
   $orderBy: [${pluralizedResourceTypeName}OrderBy!]
   ) {
-    ${manyLowerResourceName}(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
+    ${manyLowerResourceName}(
+      first: $first,
+      offset: $offset,
+      filter: $filter,
+      orderBy: $orderBy,
+      condition: $condition
+    ) {
     nodes {
       ${createQueryFromType(
         resourceTypename,


### PR DESCRIPTION
This PR allows optional support for list filters based on Postgraphile's default `condition` field (rather than relying on the connection-filter-plugin).

This allows:

```tsx
<List filter={{ condition: { customFilter: true }}} />
```

It shouldn't break compatibility with the field filter based logic, as long as the field isn't named `condition`. If that seems like a significant limitation, this PR could be modified to use a key that is less likely to be a resource field name (perhaps `$condition`? 