### PR TITLE
use optional chaining on fieldType

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,7 +101,7 @@ export const mapInputToVariables = (
       (field: any) => fieldIsObjectOrListOfObject(field) && field.name === key
     )
     if (fieldType) {
-      const valueMapperForType = typeConfiguration[fieldType.type.ofType.name]
+      const valueMapperForType = typeConfiguration[fieldType?.type?.ofType?.name]
       if (valueMapperForType && valueMapperForType.queryValueToInputValue) {
         return {
           ...current,


### PR DESCRIPTION
I enabled the geometry types and then ran into an issue. If this fix will hide other issues or is incorrect please feel free to not merge it and I will stand corrected.

I put a break point in there to find the object that was breaking in http://localhost:3000/Users/pyramation/code/impact-rewards-admin/node_modules/ra-postgraphile/build/module/utils.js

![Screen Shot 2021-07-02 at 12 35 29 PM](https://user-images.githubusercontent.com/545047/124321156-10b3d200-db32-11eb-9dda-de8415779b20.png)

This was the object, seems that somehow `ofType` was null. This then caused an error to throw, hence breaking edits.

```
{__typename: "__Type", kind: "OBJECT", name: "GeometryPoint", ofType: null}
```