### PR TITLE
More robust custom typed id column handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "clean": "trash build test",
     "prepublishOnly": "run-s build",
+    "prepare": "run-s build",
     "migrate": "node -r dotenv/config ./node_modules/graphile-migrate/dist/cli.js"
   },
   "sideEffects": false,

--- a/src/__tests__/buildQuery.spec.ts
+++ b/src/__tests__/buildQuery.spec.ts
@@ -8,5 +8,18 @@ describe('buildQuery', () => {
     expect(mapType(({ name: 'Uuid' } as any) as IntrospectionNamedTypeRef<any>, '1')).toEqual('1')
     expect(mapType(({ name: 'BigInt' } as any) as IntrospectionNamedTypeRef<any>, '1')).toEqual(1)
     expect(mapType(({ name: 'Int' } as any) as IntrospectionNamedTypeRef<any>, '1')).toEqual(1)
+    expect(
+      mapType(({ name: 'IntParseable' } as any) as IntrospectionNamedTypeRef<any>, '1234')
+    ).toEqual(1234)
+    expect(
+      mapType(({ name: 'Unmapped' } as any) as IntrospectionNamedTypeRef<any>, 'stringValue')
+    ).toEqual('stringValue')
+    expect(
+      mapType(({ name: 'Mapped' } as any) as IntrospectionNamedTypeRef<any>, '****', {
+        Mapped: {
+          queryValueToInputValue: (a) => a.charCodeAt(0),
+        },
+      })
+    ).toEqual(42)
   })
 })


### PR DESCRIPTION
This change allows for custom ID types in postgraphile schemas. Previously, the behavior was to treat String and UUID types as strings and to parse everything else as an int. Consider a column with id of type CustomString!. It would be parsed to NaN, breaking all pages using the mapType function to get its ID (e.g. edit, show, etc).

This PR alters the default behavior for mapType. If it's String or UUID, it's a string. If it's parseable as an int, it's an int, otherwise it is cast to string. Furthermore, it uses the existing TypeMapConfig option that can be passed to allow for deeper customization.